### PR TITLE
Add system probe utility and brute-force benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,3 +30,12 @@ add_executable(pdf_password_retriever
 target_include_directories(pdf_password_retriever PRIVATE include)
 
 target_compile_definitions(pdf_password_retriever PRIVATE _CRT_SECURE_NO_WARNINGS)
+
+add_executable(device_probe
+    src/device_info.cpp
+    src/util/system_info.cpp
+    src/crypto/sha2.cpp)
+
+target_include_directories(device_probe PRIVATE include)
+
+target_compile_definitions(device_probe PRIVATE _CRT_SECURE_NO_WARNINGS)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@ The Release binary will be generated at `build/Release/pdf_password_retriever.ex
 ./build/Release/pdf_password_retriever.exe --pdf secret.pdf --wordlist passwords.txt
 ```
 
+## Hardware & Benchmark Utility
+The repository also ships with `device_probe`, a helper that prints basic system information and runs a configurable brute-force
+throughput benchmark. Build it alongside the main tool:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target device_probe
+```
+
+Run the probe with optional flags to tweak the workload:
+
+```bash
+./build/device_probe --lengths 6,8,10 --attempts 750000 --hash sha256 --include-special
+```
+
+Key options:
+
+- `--lengths <list>` – Comma separated password lengths to benchmark.
+- `--attempts <n>` – Attempts per length (default: 500000).
+- `--hash <mode>` – `none` (fast hash) or `sha256` for a heavier workload.
+- `--include-special` – Adds printable punctuation to the default character set.
+- `--custom <chars>` – Provide an explicit character set for testing.
+
 ## One-Click Helper Scripts
 
 ### Windows (`build_and_run.bat`)

--- a/include/util/system_info.h
+++ b/include/util/system_info.h
@@ -1,0 +1,25 @@
+#ifndef UNLOCK_PDF_UTIL_SYSTEM_INFO_H
+#define UNLOCK_PDF_UTIL_SYSTEM_INFO_H
+
+#include <cstdint>
+#include <string>
+
+namespace unlock_pdf::util {
+
+struct SystemInfo {
+    std::string os_name;
+    std::string kernel_version;
+    std::string architecture;
+    std::string cpu_model;
+    std::string hostname;
+    unsigned int cpu_threads = 0;
+    std::uint64_t total_memory_bytes = 0;
+    std::uint64_t available_memory_bytes = 0;
+};
+
+SystemInfo collect_system_info();
+std::string human_readable_bytes(std::uint64_t bytes);
+
+}  // namespace unlock_pdf::util
+
+#endif  // UNLOCK_PDF_UTIL_SYSTEM_INFO_H

--- a/src/device_info.cpp
+++ b/src/device_info.cpp
@@ -1,0 +1,212 @@
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <cstdint>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <stdexcept>
+#include <vector>
+
+#include "crypto/sha2.h"
+#include "util/system_info.h"
+
+namespace {
+
+struct BenchmarkConfig {
+    std::size_t password_length = 8;
+    std::size_t attempts = 500000;
+    std::string charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    bool use_sha256 = false;
+};
+
+struct BenchmarkResult {
+    std::size_t password_length;
+    std::size_t attempts;
+    double duration_seconds;
+    double attempts_per_second;
+};
+
+std::vector<std::string> split_lengths(const std::string& value) {
+    std::vector<std::string> parts;
+    std::string current;
+    std::istringstream iss(value);
+    while (std::getline(iss, current, ',')) {
+        if (!current.empty()) {
+            parts.push_back(current);
+        }
+    }
+    return parts;
+}
+
+void print_help(const char* program) {
+    std::cout << "Usage: " << program << " [options]\n\n"
+              << "Options:\n"
+              << "  --attempts <n>       Number of attempts per benchmark length (default: 500000)\n"
+              << "  --lengths <list>     Comma separated password lengths to benchmark (default: 6,8,10)\n"
+              << "  --include-special    Include printable special characters in the charset\n"
+              << "  --custom <chars>     Use a custom character set (overrides other charset options)\n"
+              << "  --hash <mode>        Hash mode: none or sha256 (default: none)\n"
+              << "  --help               Show this help message\n";
+}
+
+std::string build_special_charset() {
+    return "!\"#$%&'()*+,-./:;<=>?@[]^_{|}~";
+}
+
+BenchmarkResult run_benchmark(std::size_t length, std::size_t attempts, const std::string& charset, bool use_sha256) {
+    if (charset.empty() || length == 0 || attempts == 0) {
+        return BenchmarkResult{length, attempts, 0.0, 0.0};
+    }
+
+    std::string candidate(length, charset.front());
+    const std::size_t charset_size = charset.size();
+    std::hash<std::string> hasher;
+    std::vector<unsigned char> buffer;
+    buffer.reserve(length);
+    std::vector<unsigned char> digest;
+    digest.reserve(32);
+
+    volatile std::size_t sink = 0;
+    auto start = std::chrono::steady_clock::now();
+    for (std::size_t attempt = 0; attempt < attempts; ++attempt) {
+        std::size_t value = attempt;
+        for (std::size_t pos = 0; pos < length; ++pos) {
+            candidate[pos] = charset[value % charset_size];
+            value /= charset_size;
+        }
+
+        if (use_sha256) {
+            buffer.assign(candidate.begin(), candidate.end());
+            digest = unlock_pdf::crypto::sha256_bytes(buffer);
+            sink = digest.empty() ? 0 : digest.front();
+        } else {
+            sink = hasher(candidate);
+        }
+    }
+    auto end = std::chrono::steady_clock::now();
+
+    std::chrono::duration<double> elapsed = end - start;
+    double duration = elapsed.count();
+    double throughput = duration > 0.0 ? static_cast<double>(attempts) / duration : 0.0;
+
+    // Prevent the compiler from optimizing away the benchmark loop.
+    (void)sink;
+
+    return BenchmarkResult{length, attempts, duration, throughput};
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    BenchmarkConfig config;
+    std::vector<std::size_t> lengths = {6, 8, 10};
+    bool custom_charset = false;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string_view arg(argv[i]);
+        auto require_value = [&](std::string_view option) -> std::string {
+            if (i + 1 >= argc) {
+                throw std::runtime_error("Missing value for option: " + std::string(option));
+            }
+            return argv[++i];
+        };
+
+        if (arg == "--help" || arg == "-h") {
+            print_help(argv[0]);
+            return 0;
+        } else if (arg == "--attempts") {
+            config.attempts = static_cast<std::size_t>(std::stoull(require_value(arg)));
+        } else if (arg == "--lengths") {
+            lengths.clear();
+            for (const auto& token : split_lengths(require_value(arg))) {
+                lengths.push_back(static_cast<std::size_t>(std::stoull(token)));
+            }
+        } else if (arg == "--include-special") {
+            config.charset += build_special_charset();
+        } else if (arg == "--custom") {
+            config.charset = require_value(arg);
+            custom_charset = true;
+        } else if (arg == "--hash") {
+            std::string mode = require_value(arg);
+            std::transform(mode.begin(), mode.end(), mode.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+            if (mode == "sha256") {
+                config.use_sha256 = true;
+            } else if (mode == "none") {
+                config.use_sha256 = false;
+            } else {
+                throw std::runtime_error("Unknown hash mode: " + mode);
+            }
+        } else {
+            throw std::runtime_error("Unknown option: " + std::string(arg));
+        }
+    }
+
+    if (!custom_charset) {
+        // Ensure charset contains unique characters to avoid skewing the benchmark.
+        std::string unique_charset;
+        for (char ch : config.charset) {
+            if (unique_charset.find(ch) == std::string::npos) {
+                unique_charset.push_back(ch);
+            }
+        }
+        config.charset = unique_charset;
+    }
+
+    if (config.charset.empty()) {
+        std::cerr << "Error: Character set cannot be empty." << std::endl;
+        return 1;
+    }
+
+    if (config.attempts == 0) {
+        std::cerr << "Error: Number of attempts must be greater than zero." << std::endl;
+        return 1;
+    }
+
+    std::cout << "=====================\n";
+    std::cout << "System Information\n";
+    std::cout << "=====================\n";
+    const auto info = unlock_pdf::util::collect_system_info();
+    std::cout << "Hostname:            " << info.hostname << '\n';
+    std::cout << "Operating System:    " << info.os_name;
+    if (!info.kernel_version.empty()) {
+        std::cout << " (kernel " << info.kernel_version << ')';
+    }
+    std::cout << '\n';
+    std::cout << "Architecture:        " << info.architecture << '\n';
+    std::cout << "CPU Model:           " << info.cpu_model << '\n';
+    std::cout << "Hardware Threads:    " << info.cpu_threads << '\n';
+    std::cout << "Total Memory:        " << unlock_pdf::util::human_readable_bytes(info.total_memory_bytes) << '\n';
+    std::cout << "Available Memory:    " << unlock_pdf::util::human_readable_bytes(info.available_memory_bytes) << "\n\n";
+
+    std::cout << "Benchmark Configuration\n";
+    std::cout << "------------------------\n";
+    std::cout << "Character set size:  " << config.charset.size() << '\n';
+    std::cout << "Hash mode:           " << (config.use_sha256 ? "SHA-256" : "None (std::hash)") << '\n';
+    std::cout << "Attempts per test:   " << config.attempts << "\n\n";
+
+    std::cout << std::left << std::setw(12) << "Length" << std::setw(18) << "Attempts" << std::setw(18) << "Duration (s)"
+              << "Attempts/s" << '\n';
+    std::cout << std::string(62, '-') << '\n';
+
+    for (std::size_t length : lengths) {
+        if (length == 0) {
+            continue;
+        }
+        BenchmarkResult result = run_benchmark(length, config.attempts, config.charset, config.use_sha256);
+
+        std::ostringstream duration_stream;
+        duration_stream << std::fixed << std::setprecision(4) << result.duration_seconds;
+
+        std::ostringstream throughput_stream;
+        throughput_stream << std::fixed << std::setprecision(2) << result.attempts_per_second;
+
+        std::cout << std::left << std::setw(12) << result.password_length << std::setw(18) << result.attempts
+                  << std::setw(18) << duration_stream.str() << throughput_stream.str() << '\n';
+    }
+
+    return 0;
+}

--- a/src/util/system_info.cpp
+++ b/src/util/system_info.cpp
@@ -1,0 +1,238 @@
+#include "util/system_info.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <thread>
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <winreg.h>
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <mach/mach_host.h>
+#include <mach/mach_init.h>
+#else
+#include <sys/sysinfo.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+#endif
+
+namespace unlock_pdf::util {
+namespace {
+
+std::string detect_cpu_model() {
+#if defined(_WIN32)
+    HKEY hKey;
+    if (RegOpenKeyExA(HKEY_LOCAL_MACHINE, "HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0", 0, KEY_READ, &hKey) == ERROR_SUCCESS) {
+        char buffer[256];
+        DWORD buffer_size = sizeof(buffer);
+        if (RegQueryValueExA(hKey, "ProcessorNameString", nullptr, nullptr, reinterpret_cast<LPBYTE>(buffer), &buffer_size) == ERROR_SUCCESS) {
+            RegCloseKey(hKey);
+            return std::string(buffer, buffer_size - 1);
+        }
+        RegCloseKey(hKey);
+    }
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    std::ostringstream oss;
+    oss << "Family " << sysinfo.wProcessorLevel << " Model " << sysinfo.wProcessorRevision;
+    return oss.str();
+#elif defined(__APPLE__)
+    char buffer[256];
+    size_t buffer_len = sizeof(buffer);
+    if (sysctlbyname("machdep.cpu.brand_string", &buffer, &buffer_len, nullptr, 0) == 0) {
+        return std::string(buffer, buffer_len - 1);
+    }
+    return "Unknown";
+#else
+    std::ifstream cpuinfo("/proc/cpuinfo");
+    std::string line;
+    while (std::getline(cpuinfo, line)) {
+        std::string key = "model name";
+        if (line.compare(0, key.size(), key) == 0) {
+            auto pos = line.find(':');
+            if (pos != std::string::npos) {
+                std::string value = line.substr(pos + 1);
+                value.erase(value.begin(), std::find_if(value.begin(), value.end(), [](unsigned char ch) { return !std::isspace(ch); }));
+                return value;
+            }
+        }
+    }
+    return "Unknown";
+#endif
+}
+
+std::uint64_t detect_total_memory() {
+#if defined(_WIN32)
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    if (GlobalMemoryStatusEx(&status)) {
+        return status.ullTotalPhys;
+    }
+    return 0;
+#elif defined(__APPLE__)
+    int64_t value = 0;
+    size_t size = sizeof(value);
+    if (sysctlbyname("hw.memsize", &value, &size, nullptr, 0) == 0) {
+        return static_cast<std::uint64_t>(value);
+    }
+    return 0;
+#else
+    struct sysinfo info;
+    if (sysinfo(&info) == 0) {
+        return static_cast<std::uint64_t>(info.totalram) * info.mem_unit;
+    }
+    return 0;
+#endif
+}
+
+std::uint64_t detect_available_memory() {
+#if defined(_WIN32)
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    if (GlobalMemoryStatusEx(&status)) {
+        return status.ullAvailPhys;
+    }
+    return 0;
+#elif defined(__APPLE__)
+    vm_size_t page_size;
+    mach_msg_type_number_t count = HOST_VM_INFO_COUNT;
+    vm_statistics64_data_t vm_stats;
+    if (host_page_size(mach_host_self(), &page_size) == KERN_SUCCESS &&
+        host_statistics64(mach_host_self(), HOST_VM_INFO, reinterpret_cast<host_info64_t>(&vm_stats), &count) == KERN_SUCCESS) {
+        return static_cast<std::uint64_t>(vm_stats.free_count + vm_stats.inactive_count) * page_size;
+    }
+    return 0;
+#else
+    struct sysinfo info;
+    if (sysinfo(&info) == 0) {
+        return static_cast<std::uint64_t>(info.freeram) * info.mem_unit;
+    }
+    return 0;
+#endif
+}
+
+std::string detect_os_name() {
+#if defined(_WIN32)
+    return "Windows";
+#elif defined(__APPLE__)
+    return "macOS";
+#else
+    struct utsname uts {};
+    if (uname(&uts) == 0) {
+        return uts.sysname;
+    }
+    return "Unknown";
+#endif
+}
+
+std::string detect_kernel_version() {
+#if defined(_WIN32)
+    OSVERSIONINFOEXA osvi;
+    ZeroMemory(&osvi, sizeof(osvi));
+    osvi.dwOSVersionInfoSize = sizeof(osvi);
+#pragma warning(push)
+#pragma warning(disable : 4996)
+    if (GetVersionExA(reinterpret_cast<OSVERSIONINFOA*>(&osvi))) {
+#pragma warning(pop)
+        std::ostringstream oss;
+        oss << osvi.dwMajorVersion << '.' << osvi.dwMinorVersion << " (build " << osvi.dwBuildNumber << ')';
+        return oss.str();
+    }
+    return "Unknown";
+#elif defined(__APPLE__)
+    char buffer[256];
+    size_t size = sizeof(buffer);
+    if (sysctlbyname("kern.osrelease", &buffer, &size, nullptr, 0) == 0) {
+        return std::string(buffer, size - 1);
+    }
+    return "Unknown";
+#else
+    struct utsname uts {};
+    if (uname(&uts) == 0) {
+        return uts.release;
+    }
+    return "Unknown";
+#endif
+}
+
+std::string detect_architecture() {
+#if defined(_WIN32)
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+    switch (sysinfo.wProcessorArchitecture) {
+        case PROCESSOR_ARCHITECTURE_AMD64:
+            return "x86_64";
+        case PROCESSOR_ARCHITECTURE_ARM64:
+            return "ARM64";
+        case PROCESSOR_ARCHITECTURE_INTEL:
+            return "x86";
+        default:
+            return "Unknown";
+    }
+#elif defined(__APPLE__)
+    char buffer[256];
+    size_t size = sizeof(buffer);
+    if (sysctlbyname("hw.machine", &buffer, &size, nullptr, 0) == 0) {
+        return std::string(buffer, size - 1);
+    }
+    return "Unknown";
+#else
+    struct utsname uts {};
+    if (uname(&uts) == 0) {
+        return uts.machine;
+    }
+    return "Unknown";
+#endif
+}
+
+std::string detect_hostname() {
+    std::array<char, 256> buffer{};
+    if (gethostname(buffer.data(), buffer.size()) == 0) {
+        return std::string(buffer.data());
+    }
+    return "Unknown";
+}
+
+}  // namespace
+
+SystemInfo collect_system_info() {
+    SystemInfo info;
+    info.os_name = detect_os_name();
+    info.kernel_version = detect_kernel_version();
+    info.architecture = detect_architecture();
+    info.cpu_model = detect_cpu_model();
+    info.cpu_threads = std::thread::hardware_concurrency();
+    info.total_memory_bytes = detect_total_memory();
+    info.available_memory_bytes = detect_available_memory();
+    info.hostname = detect_hostname();
+    return info;
+}
+
+std::string human_readable_bytes(std::uint64_t bytes) {
+    if (bytes == 0) {
+        return "0 B";
+    }
+
+    constexpr std::array<const char*, 7> suffixes = {"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"};
+    double count = static_cast<double>(bytes);
+    std::size_t suffix_index = 0;
+    while (count >= 1024.0 && suffix_index + 1 < suffixes.size()) {
+        count /= 1024.0;
+        ++suffix_index;
+    }
+
+    std::ostringstream oss;
+    oss.setf(std::ios::fixed);
+    oss.precision(count < 10.0 && suffix_index > 0 ? 2 : 0);
+    oss << count << ' ' << suffixes[suffix_index];
+    return oss.str();
+}
+
+}  // namespace unlock_pdf::util


### PR DESCRIPTION
## Summary
- add a reusable system information helper for detecting OS, CPU, and memory details
- introduce a device_probe executable that reports hardware information and runs configurable brute-force benchmarks
- document how to build and use the new utility in the README

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build --target device_probe
- ./build/device_probe --lengths 4,6 --attempts 1000 --hash none

------
