### PR TITLE
Fix Windows hostname detection and linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,3 +39,7 @@ add_executable(device_probe
 target_include_directories(device_probe PRIVATE include)
 
 target_compile_definitions(device_probe PRIVATE _CRT_SECURE_NO_WARNINGS)
+
+if (WIN32)
+    target_link_libraries(device_probe PRIVATE ws2_32)
+endif()

--- a/src/util/system_info.cpp
+++ b/src/util/system_info.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 
 #if defined(_WIN32)
+#include <winsock2.h>
 #include <windows.h>
 #include <winreg.h>
 #elif defined(__APPLE__)
@@ -193,11 +194,20 @@ std::string detect_architecture() {
 }
 
 std::string detect_hostname() {
+#if defined(_WIN32)
+    std::array<char, 256> buffer{};
+    DWORD size = static_cast<DWORD>(buffer.size());
+    if (GetComputerNameA(buffer.data(), &size)) {
+        return std::string(buffer.data(), size);
+    }
+    return "Unknown";
+#else
     std::array<char, 256> buffer{};
     if (gethostname(buffer.data(), buffer.size()) == 0) {
         return std::string(buffer.data());
     }
     return "Unknown";
+#endif
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- include Winsock before Windows headers and use `GetComputerNameA` so hostname detection no longer depends on implicit Winsock initialization
- link the `device_probe` executable against `ws2_32` when building on Windows

## Testing
- not run (not on Windows)


------
