### PR TITLE
Document Windows device_probe binary location

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ Run the probe with optional flags to tweak the workload:
 ./build/device_probe --lengths 6,8,10 --attempts 750000 --hash sha256 --include-special
 ```
 
+On Windows builds generated with MSBuild, specify the configuration and use the corresponding
+subdirectory when launching the executable:
+
+```powershell
+cmake --build build --target device_probe --config Release
+./build/Release/device_probe.exe --lengths 6,8,10 --attempts 750000 --hash sha256 --include-special
+```
+If you keep the default Debug configuration (for example by omitting `--config Release`), the
+binary will instead be located at `build/Debug/device_probe.exe`.
+
 Key options:
 
 - `--lengths <list>` – Comma separated password lengths to benchmark.


### PR DESCRIPTION
## Summary
- clarify how to build and run the `device_probe` utility on Windows, including the correct executable paths for each configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d93d40e22483328e6a8a675ad5a45d