### PR TITLE
Add Windows helper for maximum speed builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ Run the helper from an existing Command Prompt/PowerShell session or double-clic
   - `--build-dir <dir>` – use a custom build folder.
   - `--debug` – configure a Debug build instead of Release.
 
+### Windows (`full_speed_build_and_run.bat`)
+```powershell
+full_speed_build_and_run.bat --pdf secret.pdf [--wordlist rockyou.txt] [--threads 12]
+```
+- Always configures and compiles a **Release** build for maximum CPU throughput.
+- Cleans the build directory (default: `build`) before configuring to avoid generator/platform mismatches. Pass `--no-clean` if you want to reuse an existing build tree.
+- Auto-detects your logical core count (capped at 16 threads) and passes it to the cracker. Override with `--threads <n>`.
+- Supports the common CLI options directly: `--pdf`, `--wordlist`, `--min-length`, `--max-length`, `--threads`, and `--build-dir`.
+- Forward any other cracker flags by appending `--` followed by the desired arguments, for example:
+  ```powershell
+  full_speed_build_and_run.bat --pdf secret.pdf -- --include-digits --include-lowercase --min-length 6 --max-length 8
+  ```
+
 ### Linux (`build_and_run_linux.sh`)
 ```bash
 ./build_and_run_linux.sh

--- a/full_speed_build_and_run.bat
+++ b/full_speed_build_and_run.bat
@@ -1,0 +1,216 @@
+@echo off
+setlocal enabledelayedexpansion
+
+rem Ensure the script runs from the repository root
+pushd "%~dp0" >nul
+
+set "BUILD_DIR=build"
+set "TARGET=pdf_password_retriever"
+set "BUILD_TYPE=Release"
+set "PDF=file.pdf"
+set "WORDLIST="
+set "MIN_LENGTH="
+set "MAX_LENGTH="
+set "CLEAN_BUILD=1"
+set "EXIT_CODE=0"
+set "EXTRA_ARGS="
+
+set "THREADS=%NUMBER_OF_PROCESSORS%"
+if not defined THREADS set "THREADS=0"
+for /f "delims=0123456789" %%A in ("%THREADS%") do set "THREADS="
+if not defined THREADS set "THREADS=0"
+set /a THREADS=THREADS 2>nul
+if errorlevel 1 set "THREADS=0"
+if %THREADS% LSS 1 set "THREADS=4"
+if %THREADS% GTR 16 set "THREADS=16"
+
+:parse_args
+if "%~1"=="" goto args_done
+if /I "%~1"=="--pdf" (
+    shift
+    if "%~1"=="" (
+        echo Missing value for --pdf
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    set "PDF=%~1"
+    shift
+    goto parse_args
+)
+if /I "%~1"=="--wordlist" (
+    shift
+    if "%~1"=="" (
+        echo Missing value for --wordlist
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    set "WORDLIST=%~1"
+    shift
+    goto parse_args
+)
+if /I "%~1"=="--threads" (
+    shift
+    if "%~1"=="" (
+        echo Missing value for --threads
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    set "THREADS_VAL=%~1"
+    for /f "delims=0123456789" %%A in ("%THREADS_VAL%") do set "THREADS_VAL="
+    if not defined THREADS_VAL (
+        echo Invalid numeric value supplied to --threads
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    set /a THREADS=%~1 2>nul
+    if errorlevel 1 (
+        echo Invalid numeric value supplied to --threads
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    if %THREADS% LSS 1 set "THREADS=1"
+    if %THREADS% GTR 16 set "THREADS=16"
+    shift
+    goto parse_args
+)
+if /I "%~1"=="--min-length" (
+    shift
+    if "%~1"=="" (
+        echo Missing value for --min-length
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    set "MIN_VAL=%~1"
+    for /f "delims=0123456789" %%A in ("%MIN_VAL%") do set "MIN_VAL="
+    if not defined MIN_VAL (
+        echo Invalid numeric value supplied to --min-length
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    set /a MIN_LENGTH=%~1 2>nul
+    if errorlevel 1 (
+        echo Invalid numeric value supplied to --min-length
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    shift
+    goto parse_args
+)
+if /I "%~1"=="--max-length" (
+    shift
+    if "%~1"=="" (
+        echo Missing value for --max-length
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    set "MAX_VAL=%~1"
+    for /f "delims=0123456789" %%A in ("%MAX_VAL%") do set "MAX_VAL="
+    if not defined MAX_VAL (
+        echo Invalid numeric value supplied to --max-length
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    set /a MAX_LENGTH=%~1 2>nul
+    if errorlevel 1 (
+        echo Invalid numeric value supplied to --max-length
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    shift
+    goto parse_args
+)
+if /I "%~1"=="--build-dir" (
+    shift
+    if "%~1"=="" (
+        echo Missing value for --build-dir
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+    set "BUILD_DIR=%~1"
+    shift
+    goto parse_args
+)
+if /I "%~1"=="--no-clean" (
+    set "CLEAN_BUILD=0"
+    shift
+    goto parse_args
+)
+if "%~1"=="--" (
+    shift
+    set "EXTRA_ARGS=%*"
+    goto args_done
+)
+echo Unknown option: %~1
+set "EXIT_CODE=1"
+goto cleanup
+
+:args_done
+
+if not exist "%PDF%" (
+    echo PDF "%PDF%" not found.
+    set "EXIT_CODE=1"
+    goto cleanup
+)
+
+if defined WORDLIST (
+    if not exist "%WORDLIST%" (
+        echo Wordlist "%WORDLIST%" not found.
+        set "EXIT_CODE=1"
+        goto cleanup
+    )
+)
+
+if "%CLEAN_BUILD%"=="1" (
+    if exist "%BUILD_DIR%" (
+        echo Removing existing build directory "%BUILD_DIR%" for a clean Release configuration...
+        rmdir /s /q "%BUILD_DIR%"
+    )
+)
+
+cmake -S . -B "%BUILD_DIR%" -A x64 -DCMAKE_BUILD_TYPE=%BUILD_TYPE%
+if errorlevel 1 (
+    echo CMake configuration failed.
+    set "EXIT_CODE=1"
+    goto cleanup
+)
+
+cmake --build "%BUILD_DIR%" --config %BUILD_TYPE%
+if errorlevel 1 (
+    echo Build failed.
+    set "EXIT_CODE=1"
+    goto cleanup
+)
+
+set "EXEC=%BUILD_DIR%\%TARGET%.exe"
+if not exist "%EXEC%" (
+    set "EXEC=%BUILD_DIR%\%BUILD_TYPE%\%TARGET%.exe"
+)
+
+if not exist "%EXEC%" (
+    echo Could not find %TARGET%.exe after building.
+    set "EXIT_CODE=1"
+    goto cleanup
+)
+
+if %THREADS% LSS 1 set "THREADS=1"
+if %THREADS% GTR 16 set "THREADS=16"
+
+set "RUN_ARGS=--threads %THREADS% --pdf ^"%PDF%^""
+if defined WORDLIST set "RUN_ARGS=!RUN_ARGS! --wordlist ^"%WORDLIST%^""
+if defined MIN_LENGTH set "RUN_ARGS=!RUN_ARGS! --min-length %MIN_LENGTH%"
+if defined MAX_LENGTH set "RUN_ARGS=!RUN_ARGS! --max-length %MAX_LENGTH%"
+if defined EXTRA_ARGS set "RUN_ARGS=!RUN_ARGS! %EXTRA_ARGS%"
+
+echo.
+echo Launching %TARGET%.exe with %THREADS% thread^(s^):
+echo    !RUN_ARGS!
+echo.
+"%EXEC%" !RUN_ARGS!
+set "EXIT_CODE=%ERRORLEVEL%"
+
+goto cleanup
+
+:cleanup
+echo.
+popd >nul
+endlocal & exit /b %EXIT_CODE%


### PR DESCRIPTION
## Summary
- add a Windows batch helper that cleans and rebuilds the project in Release mode before launching the cracker with the maximum usable CPU threads
- document how to use the new helper and how to forward extra command-line options

## Testing
- not run (batch helper only)


------
https://chatgpt.com/codex/tasks/task_e_68d943f74a948332b1cc4464cdb5da4b