### PR TITLE
Improve feedback in Windows fast runner

### DIFF
--- a/full_speed_build_and_run.bat
+++ b/full_speed_build_and_run.bat
@@ -14,6 +14,7 @@ set "MAX_LENGTH="
 set "CLEAN_BUILD=1"
 set "EXIT_CODE=0"
 set "EXTRA_ARGS="
+set "NOPAUSE=0"
 
 set "THREADS=%NUMBER_OF_PROCESSORS%"
 if not defined THREADS set "THREADS=0"
@@ -130,6 +131,11 @@ if /I "%~1"=="--build-dir" (
     shift
     goto parse_args
 )
+if /I "%~1"=="--no-pause" (
+    set "NOPAUSE=1"
+    shift
+    goto parse_args
+)
 if /I "%~1"=="--no-clean" (
     set "CLEAN_BUILD=0"
     shift
@@ -195,22 +201,36 @@ if not exist "%EXEC%" (
 if %THREADS% LSS 1 set "THREADS=1"
 if %THREADS% GTR 16 set "THREADS=16"
 
-set "RUN_ARGS=--threads %THREADS% --pdf ^"%PDF%^""
-if defined WORDLIST set "RUN_ARGS=!RUN_ARGS! --wordlist ^"%WORDLIST%^""
-if defined MIN_LENGTH set "RUN_ARGS=!RUN_ARGS! --min-length %MIN_LENGTH%"
-if defined MAX_LENGTH set "RUN_ARGS=!RUN_ARGS! --max-length %MAX_LENGTH%"
-if defined EXTRA_ARGS set "RUN_ARGS=!RUN_ARGS! %EXTRA_ARGS%"
+set RUN_ARGS=--threads %THREADS% --pdf "%PDF%"
+if defined WORDLIST set RUN_ARGS=%RUN_ARGS% --wordlist "%WORDLIST%"
+if defined MIN_LENGTH set RUN_ARGS=%RUN_ARGS% --min-length %MIN_LENGTH%
+if defined MAX_LENGTH set RUN_ARGS=%RUN_ARGS% --max-length %MAX_LENGTH%
+if defined EXTRA_ARGS set RUN_ARGS=%RUN_ARGS% %EXTRA_ARGS%
 
 echo.
 echo Launching %TARGET%.exe with %THREADS% thread^(s^):
-echo    !RUN_ARGS!
+echo    %RUN_ARGS%
 echo.
-"%EXEC%" !RUN_ARGS!
+call "%EXEC%" %RUN_ARGS%
 set "EXIT_CODE=%ERRORLEVEL%"
+
+echo.
+if %EXIT_CODE% EQU 0 (
+    echo Execution completed successfully.
+) else if %EXIT_CODE% EQU 1 (
+    echo The executable reported an error. Review the output above for details.
+) else if %EXIT_CODE% EQU 2 (
+    echo Completed execution, but no matching password was found with the provided settings.
+) else (
+    echo The executable exited with unexpected code %EXIT_CODE%.
+)
 
 goto cleanup
 
 :cleanup
 echo.
 popd >nul
+if not "%NOPAUSE%"=="1" (
+    pause
+)
 endlocal & exit /b %EXIT_CODE%


### PR DESCRIPTION
## Summary
- add exit-code messaging to `full_speed_build_and_run.bat` so users can see what happened
- add an optional `--no-pause` flag and pause by default so the window stays open when double-clicked
- ensure the PDF argument is quoted correctly when launching `pdf_password_retriever.exe`

## Testing
- not run (Windows-only batch script change)


------
https://chatgpt.com/codex/tasks/task_e_68d9481a1128833294ad51e9991d3ace