### PR TITLE
Add Windows launcher and device probe support to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,15 @@ If you prefer a point-and-click workflow, a Tkinter-based launcher is available 
    python3 gui/unlock_pdf_gui.py
    ```
 
+   On Windows you can also double-click `gui/unlock_pdf_gui.pyw`. The `.pyw` extension opens the
+   interface with `pythonw.exe`, so it behaves like a regular desktop application without a console
+   window popping up.
+
 3. Use the "Browse" buttons to choose the executable, encrypted PDF, and optional wordlist.
 4. Adjust the password generation options, then click **Run Crack** or **Get PDF Info** to launch the command.
+5. To benchmark your hardware, set the `device_probe` path (built via CMake) and click **Run Device Probe**.
+   Provide additional probe flags in the **Probe Options** field—anything you type there is passed directly
+   to the helper executable.
 
 The GUI streams the CLI output in real time and lets you stop the process if needed. Tkinter ships with most Python distributions;
 if it is missing, install the appropriate `python3-tk` package for your platform.

--- a/gui/unlock_pdf_gui.pyw
+++ b/gui/unlock_pdf_gui.pyw
@@ -1,0 +1,7 @@
+"""Windows-friendly launcher for the Unlock PDF Tkinter GUI."""
+
+from unlock_pdf_gui import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add default paths, fields, and button to run the device_probe benchmark from the Tkinter GUI
- provide a Windows-friendly .pyw launcher so the interface can be opened via double-click
- update documentation to explain the launcher and new device_probe workflow

## Testing
- python -m compileall gui/unlock_pdf_gui.py gui/unlock_pdf_gui.pyw

------
https://chatgpt.com/codex/tasks/task_e_68dc3a145e7c8332a54bfc90f43acda5