### PR TITLE
Add PDF workload benchmark to device_probe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,22 @@ target_compile_definitions(pdf_password_retriever PRIVATE _CRT_SECURE_NO_WARNING
 add_executable(device_probe
     src/device_info.cpp
     src/util/system_info.cpp
+    src/pdf/pdf_parser.cpp
+    src/pdf/encryption/encryption_handler_registry.cpp
+    src/pdf/encryption/standard_security_utils.cpp
+    src/pdf/encryption/rc4_40_handler.cpp
+    src/pdf/encryption/rc4_128_handler.cpp
+    src/pdf/encryption/aes128_handler.cpp
+    src/pdf/encryption/aes256_handler.cpp
+    src/pdf/encryption/standard_r3_handler.cpp
+    src/pdf/encryption/pki_handler.cpp
+    src/pdf/encryption/password_handler.cpp
+    src/pdf/encryption/open_handler.cpp
+    src/pdf/encryption/owner_password_handler.cpp
+    src/pdf/encryption/x509_handler.cpp
+    src/crypto/aes.cpp
+    src/crypto/md5.cpp
+    src/crypto/rc4.cpp
     src/crypto/sha2.cpp)
 
 target_include_directories(device_probe PRIVATE include)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Run the probe with optional flags to tweak the workload:
 ./build/device_probe --lengths 6,8,10 --attempts 750000 --hash sha256 --include-special
 ```
 
+To measure your hardware against the real password-check routine, point the probe at an encrypted PDF:
+
+```bash
+./build/device_probe --pdf secret.pdf --lengths 6,8 --attempts 2500
+```
+
 On Windows builds generated with MSBuild, specify the configuration and use the corresponding
 subdirectory when launching the executable:
 
@@ -55,6 +61,7 @@ Key options:
 - `--lengths <list>` – Comma separated password lengths to benchmark.
 - `--attempts <n>` – Attempts per length (default: 500000).
 - `--hash <mode>` – `none` (fast hash) or `sha256` for a heavier workload.
+- `--pdf <path>` – Switch to the real PDF password-check workload using metadata from the specified file.
 - `--include-special` – Adds printable punctuation to the default character set.
 - `--custom <chars>` – Provide an explicit character set for testing.
 

--- a/src/device_info.cpp
+++ b/src/device_info.cpp
@@ -13,15 +13,30 @@
 #include <vector>
 
 #include "crypto/sha2.h"
+#include "pdf/encryption/encryption_handler_registry.h"
+#include "pdf/encryption/encryption_handler.h"
+#include "pdf/pdf_parser.h"
 #include "util/system_info.h"
 
 namespace {
+
+enum class Workload {
+    Synthetic,
+    Pdf
+};
+
+enum class HashMode {
+    StdHash,
+    Sha256
+};
 
 struct BenchmarkConfig {
     std::size_t password_length = 8;
     std::size_t attempts = 500000;
     std::string charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    bool use_sha256 = false;
+    Workload workload = Workload::Synthetic;
+    HashMode hash_mode = HashMode::StdHash;
+    std::string pdf_path;
 };
 
 struct BenchmarkResult {
@@ -50,7 +65,8 @@ void print_help(const char* program) {
               << "  --lengths <list>     Comma separated password lengths to benchmark (default: 6,8,10)\n"
               << "  --include-special    Include printable special characters in the charset\n"
               << "  --custom <chars>     Use a custom character set (overrides other charset options)\n"
-              << "  --hash <mode>        Hash mode: none or sha256 (default: none)\n"
+              << "  --hash <mode>        Synthetic hash mode: none or sha256 (default: none)\n"
+              << "  --pdf <path>         Benchmark the real PDF password check using metadata from <path>\n"
               << "  --help               Show this help message\n";
 }
 
@@ -58,7 +74,10 @@ std::string build_special_charset() {
     return "!\"#$%&'()*+,-./:;<=>?@[]^_{|}~";
 }
 
-BenchmarkResult run_benchmark(std::size_t length, std::size_t attempts, const std::string& charset, bool use_sha256) {
+BenchmarkResult run_benchmark(std::size_t length,
+                              std::size_t attempts,
+                              const std::string& charset,
+                              bool use_sha256) {
     if (charset.empty() || length == 0 || attempts == 0) {
         return BenchmarkResult{length, attempts, 0.0, 0.0};
     }
@@ -108,6 +127,92 @@ BenchmarkResult run_benchmark(std::size_t length, std::size_t attempts, const st
     return BenchmarkResult{length, attempts, duration, throughput};
 }
 
+std::vector<const unlock_pdf::pdf::EncryptionHandler*> collect_password_handlers(
+    const unlock_pdf::pdf::PDFEncryptInfo& info,
+    const std::vector<unlock_pdf::pdf::EncryptionHandlerPtr>& handlers) {
+    std::vector<const unlock_pdf::pdf::EncryptionHandler*> password_handlers;
+    password_handlers.reserve(handlers.size());
+    for (const auto& handler : handlers) {
+        if (!handler) {
+            continue;
+        }
+        if (!handler->can_handle(info) || !handler->requires_password()) {
+            continue;
+        }
+        password_handlers.push_back(handler.get());
+    }
+    return password_handlers;
+}
+
+int effective_key_length_bits(const unlock_pdf::pdf::PDFEncryptInfo& info) {
+    if (info.length > 0) {
+        return info.length;
+    }
+    if (info.revision <= 0) {
+        return 0;
+    }
+    if (info.revision <= 2) {
+        return 40;
+    }
+    if (info.revision <= 4) {
+        return 128;
+    }
+    return 256;
+}
+
+BenchmarkResult run_pdf_benchmark(std::size_t length,
+                                  std::size_t attempts,
+                                  const std::string& charset,
+                                  const unlock_pdf::pdf::PDFEncryptInfo& info,
+                                  const std::vector<const unlock_pdf::pdf::EncryptionHandler*>& handlers) {
+    if (charset.empty() || length == 0 || attempts == 0 || handlers.empty()) {
+        return BenchmarkResult{length, attempts, 0.0, 0.0};
+    }
+
+    const std::size_t charset_size = charset.size();
+    const char first_char = charset.front();
+    const char* charset_data = charset.data();
+    std::string candidate(length, first_char);
+    std::vector<std::size_t> indices(length, 0);
+    std::string matched_variant;
+
+    volatile bool sink = false;
+    auto start = std::chrono::steady_clock::now();
+    for (std::size_t attempt = 0; attempt < attempts; ++attempt) {
+        bool matched = false;
+        matched_variant.clear();
+        for (const auto* handler : handlers) {
+            if (handler->check_password(candidate, info, matched_variant)) {
+                matched = true;
+                break;
+            }
+        }
+        sink = sink || matched;
+
+        std::size_t pos = 0;
+        while (pos < length) {
+            std::size_t next_index = indices[pos] + 1;
+            if (next_index < charset_size) {
+                indices[pos] = next_index;
+                candidate[pos] = charset_data[next_index];
+                break;
+            }
+            indices[pos] = 0;
+            candidate[pos] = first_char;
+            ++pos;
+        }
+    }
+    auto end = std::chrono::steady_clock::now();
+
+    std::chrono::duration<double> elapsed = end - start;
+    double duration = elapsed.count();
+    double throughput = duration > 0.0 ? static_cast<double>(attempts) / duration : 0.0;
+
+    (void)sink;
+
+    return BenchmarkResult{length, attempts, duration, throughput};
+}
+
 }  // namespace
 
 int main(int argc, char* argv[]) {
@@ -143,12 +248,15 @@ int main(int argc, char* argv[]) {
             std::string mode = require_value(arg);
             std::transform(mode.begin(), mode.end(), mode.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
             if (mode == "sha256") {
-                config.use_sha256 = true;
+                config.hash_mode = HashMode::Sha256;
             } else if (mode == "none") {
-                config.use_sha256 = false;
+                config.hash_mode = HashMode::StdHash;
             } else {
                 throw std::runtime_error("Unknown hash mode: " + mode);
             }
+        } else if (arg == "--pdf") {
+            config.workload = Workload::Pdf;
+            config.pdf_path = require_value(arg);
         } else {
             throw std::runtime_error("Unknown option: " + std::string(arg));
         }
@@ -175,6 +283,32 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    unlock_pdf::pdf::PDFEncryptInfo pdf_info;
+    std::vector<unlock_pdf::pdf::EncryptionHandlerPtr> handler_storage;
+    std::vector<const unlock_pdf::pdf::EncryptionHandler*> password_handlers;
+
+    if (config.workload == Workload::Pdf) {
+        if (config.pdf_path.empty()) {
+            std::cerr << "Error: --pdf requires a file path." << std::endl;
+            return 1;
+        }
+        if (config.hash_mode == HashMode::Sha256) {
+            std::cerr << "Error: --hash sha256 cannot be combined with --pdf." << std::endl;
+            return 1;
+        }
+
+        if (!unlock_pdf::pdf::read_pdf_encrypt_info(config.pdf_path, pdf_info)) {
+            return 1;
+        }
+
+        handler_storage = unlock_pdf::pdf::create_default_encryption_handlers();
+        password_handlers = collect_password_handlers(pdf_info, handler_storage);
+        if (password_handlers.empty()) {
+            std::cerr << "Error: No password-based handlers are applicable to the provided PDF." << std::endl;
+            return 1;
+        }
+    }
+
     std::cout << "=====================\n";
     std::cout << "System Information\n";
     std::cout << "=====================\n";
@@ -194,7 +328,28 @@ int main(int argc, char* argv[]) {
     std::cout << "Benchmark Configuration\n";
     std::cout << "------------------------\n";
     std::cout << "Character set size:  " << config.charset.size() << '\n';
-    std::cout << "Hash mode:           " << (config.use_sha256 ? "SHA-256" : "None (std::hash)") << '\n';
+    if (config.workload == Workload::Pdf) {
+        std::cout << "Workload:           PDF password check" << '\n';
+        std::cout << "PDF file:           " << config.pdf_path << '\n';
+        if (!pdf_info.filter.empty()) {
+            std::cout << "Filter:             " << pdf_info.filter << '\n';
+        }
+        if (!pdf_info.sub_filter.empty()) {
+            std::cout << "SubFilter:          " << pdf_info.sub_filter << '\n';
+        }
+        if (pdf_info.revision != 0) {
+            std::cout << "Revision:           R" << pdf_info.revision << '\n';
+        }
+        int key_length = effective_key_length_bits(pdf_info);
+        if (key_length > 0) {
+            std::cout << "Key length:         " << key_length << " bits" << '\n';
+        }
+        std::cout << "Password handlers:  " << password_handlers.size() << '\n';
+    } else {
+        std::cout << "Workload:           Synthetic hash" << '\n';
+        std::cout << "Hash mode:          "
+                  << (config.hash_mode == HashMode::Sha256 ? "SHA-256" : "None (std::hash)") << '\n';
+    }
     std::cout << "Attempts per test:   " << config.attempts << "\n\n";
 
     std::cout << std::left << std::setw(12) << "Length" << std::setw(18) << "Attempts" << std::setw(18) << "Duration (s)"
@@ -205,7 +360,15 @@ int main(int argc, char* argv[]) {
         if (length == 0) {
             continue;
         }
-        BenchmarkResult result = run_benchmark(length, config.attempts, config.charset, config.use_sha256);
+        BenchmarkResult result;
+        if (config.workload == Workload::Pdf) {
+            result = run_pdf_benchmark(length, config.attempts, config.charset, pdf_info, password_handlers);
+        } else {
+            result = run_benchmark(length,
+                                   config.attempts,
+                                   config.charset,
+                                   config.hash_mode == HashMode::Sha256);
+        }
 
         std::ostringstream duration_stream;
         duration_stream << std::fixed << std::setprecision(4) << result.duration_seconds;


### PR DESCRIPTION
## Summary
- add a PDF password-check workload to `device_probe` so throughput reflects the real cracking cost
- pull the encryption handlers and crypto utilities into the probe target so the new benchmark can execute
- document the new `--pdf` option and provide an example invocation in the README

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build --target device_probe
- ./build/device_probe --pdf Test1.pdf --lengths 6 --attempts 10


------
https://chatgpt.com/codex/tasks/task_e_68dc3d5066f4833282d75a194d9aaeda