### PR TITLE
Clarify device_probe PDF benchmarking

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ To measure your hardware against the real password-check routine, point the prob
 ./build/device_probe --pdf secret.pdf --lengths 6,8 --attempts 2500
 ```
 
+The repository includes `Test1.pdf`, a small encrypted sample you can use to validate the "real" workload:
+
+```bash
+./build/device_probe --pdf Test1.pdf --lengths 6,8 --attempts 2500
+```
+
+The PDF mode performs the same password verification logic as the main cracker, so expect the attempts-per-second figures to be
+significantly lower than the synthetic hash benchmark. Increase `--attempts` only after confirming the run completes successfully.
+
 On Windows builds generated with MSBuild, specify the configuration and use the corresponding
 subdirectory when launching the executable:
 

--- a/src/device_info.cpp
+++ b/src/device_info.cpp
@@ -349,6 +349,7 @@ int main(int argc, char* argv[]) {
         std::cout << "Workload:           Synthetic hash" << '\n';
         std::cout << "Hash mode:          "
                   << (config.hash_mode == HashMode::Sha256 ? "SHA-256" : "None (std::hash)") << '\n';
+        std::cout << "Note:               Use --pdf <file.pdf> to benchmark the real PDF password check." << '\n';
     }
     std::cout << "Attempts per test:   " << config.attempts << "\n\n";
 


### PR DESCRIPTION
## Summary
- add an inline note reminding users how to switch device_probe from the synthetic workload to a real PDF check
- document how to benchmark with the bundled Test1.pdf sample and explain the expected performance difference

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc43efe7c88332a77b84fbef3ce853