### PR TITLE
Expose encryption method details for older PDFs

### DIFF
--- a/include/pdf/pdf_types.h
+++ b/include/pdf/pdf_types.h
@@ -17,6 +17,8 @@ struct PDFEncryptInfo {
     std::string stream_filter;
     std::string string_filter;
     std::string ef_filter;
+    std::string crypt_filter;
+    std::string crypt_filter_method;
     int version = 0;
     int revision = 0;
     int length = 0;


### PR DESCRIPTION
## Summary
- add storage for the selected crypt filter and its method in `PDFEncryptInfo`
- parse the /CF dictionary to resolve crypt filter methods referenced by StmF/StrF entries
- always print encryption and method details, using captured crypt filter data or heuristics for older revisions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc498721e08332ba66585fc437a2d7