### PR TITLE
Configure hex diff for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+*.pdf binary diff=hex
+*.bin binary diff=hex
+*.exe binary diff=hex
+*.dll binary diff=hex
+*.dat binary diff=hex
+*.zip binary diff=hex
+*.tar binary diff=hex
+*.gz binary diff=hex
+*.7z binary diff=hex
+*.png binary diff=hex
+*.jpg binary diff=hex
+*.jpeg binary diff=hex
+*.bmp binary diff=hex
+*.gif binary diff=hex

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[diff "hex"]
+        textconv = hexdump -v -C
+        binary = true


### PR DESCRIPTION
## Summary
- add a shared `diff.hex` configuration to hexdump binary files when diffed
- register common binary extensions to use the custom hex diff driver

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68dfce2be7388332b15814d18198822c