### PR TITLE
Configure hex diff driver for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+# Use a custom hex diff driver for common binary assets
 *.pdf binary diff=hex
 *.bin binary diff=hex
 *.exe binary diff=hex

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,3 @@
+[diff "hex"]
+    textconv = hexdump -v -C
+    binary = true


### PR DESCRIPTION
## Summary
- add a repository git config snippet that defines a hex diff driver backed by hexdump
- ensure common binary file patterns use the hex diff driver via .gitattributes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfd107d46c833294e3d3384e93ff34