### PR TITLE
Configure hex diff driver for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # Use a custom hex diff driver for common binary assets
+# See diff-hex.config for the driver configuration snippet.
 *.pdf binary diff=hex
 *.bin binary diff=hex
 *.exe binary diff=hex

--- a/diff-hex.config
+++ b/diff-hex.config
@@ -1,0 +1,3 @@
+[diff "hex"]
+    textconv = hexdump -v -C
+    binary = true


### PR DESCRIPTION
## Summary
- document the custom `diff.hex` driver configuration snippet for use in local Git settings
- ensure common binary artifacts use the hex diff driver via repository `.gitattributes`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd4bcbf048332a339a8a5096010f8