### PR TITLE
Improve Unlock PDF Tkinter GUI experience

### DIFF
--- a/gui/unlock_pdf_gui.py
+++ b/gui/unlock_pdf_gui.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Simple Tkinter GUI for the pdf_password_retriever CLI."""
+"""Tkinter based GUI for running the ``pdf_password_retriever`` helpers.
+
+The original implementation bundled all widget creation in a single block and
+relied on the default Tk widgets.  This version reorganises the layout into
+clearly labelled sections, introduces themed widgets via :mod:`tkinter.ttk`, and
+adds quality-of-life features such as progress feedback, clearer status
+messaging, and helper text for the user.  The functional behaviour remains the
+same while providing a more welcoming interface and easier to follow code.
+"""
 
 from __future__ import annotations
 
@@ -10,6 +18,7 @@ import threading
 import tkinter as tk
 from pathlib import Path
 from tkinter import filedialog, messagebox, scrolledtext
+from tkinter import ttk
 
 
 def default_binary_path() -> str:
@@ -31,10 +40,12 @@ def default_device_probe_path() -> str:
 
 
 class UnlockPDFGui:
+    """Create and manage the password retriever interface."""
+
     def __init__(self, master: tk.Tk) -> None:
         self.master = master
         master.title("PDF Password Retriever")
-        master.geometry("760x620")
+        master.minsize(820, 680)
 
         self._runner: threading.Thread | None = None
         self._stop_event = threading.Event()
@@ -55,37 +66,96 @@ class UnlockPDFGui:
         self.use_custom_only = tk.BooleanVar(value=False)
         self.status_var = tk.StringVar(value="Idle")
 
-        self._char_checkbuttons: list[tk.Checkbutton] = []
+        self._char_checkbuttons: list[ttk.Checkbutton] = []
 
+        self._configure_style()
         self._build_widgets()
+        self.master.protocol("WM_DELETE_WINDOW", self._on_close)
 
+    def _configure_style(self) -> None:
+        """Apply a modern ttk theme and tweak a few defaults."""
+
+        style = ttk.Style()
+        preferred_theme = "clam"
+        if preferred_theme in style.theme_names():
+            style.theme_use(preferred_theme)
+
+        style.configure("Section.TLabelframe", padding=12)
+        style.configure("Section.TLabelframe.Label", font=("TkDefaultFont", 11, "bold"))
+        style.configure("Status.TLabel", font=("TkDefaultFont", 10, "bold"))
+        style.configure("Intro.TLabel", wraplength=720, justify=tk.LEFT)
+
+        self.master.option_add("*TEntry*Padding", 4)
+        self.master.option_add("*TButton*Padding", 6)
+
+    # ------------------------------------------------------------------
+    # Widget construction
+    # ------------------------------------------------------------------
     def _build_widgets(self) -> None:
-        main_frame = tk.Frame(self.master, padx=10, pady=10)
-        main_frame.pack(fill=tk.BOTH, expand=True)
+        main_frame = ttk.Frame(self.master, padding=15)
+        main_frame.grid(row=0, column=0, sticky=tk.NSEW)
 
-        def add_labeled_entry(row: int, label: str, textvariable: tk.StringVar, browse: bool = False,
-                              command=None) -> tk.Entry:
-            tk.Label(main_frame, text=label).grid(row=row, column=0, sticky=tk.W, pady=3)
-            entry = tk.Entry(main_frame, textvariable=textvariable, width=60)
-            entry.grid(row=row, column=1, sticky=tk.W, pady=3)
-            if browse:
-                tk.Button(main_frame, text="Browse", command=command).grid(row=row, column=2, padx=5)
-            return entry
+        self.master.columnconfigure(0, weight=1)
+        self.master.rowconfigure(0, weight=1)
+        main_frame.columnconfigure(0, weight=1)
 
-        add_labeled_entry(0, "Binary:", self.binary_var, browse=True, command=self._choose_binary)
-        add_labeled_entry(1, "Device Probe:", self.device_probe_var, browse=True,
-                          command=self._choose_device_probe)
-        add_labeled_entry(2, "Probe Options:", self.device_probe_args_var)
-        add_labeled_entry(3, "PDF File:", self.pdf_var, browse=True, command=self._choose_pdf)
-        add_labeled_entry(4, "Wordlist:", self.wordlist_var, browse=True, command=self._choose_wordlist)
+        intro = ttk.Label(
+            main_frame,
+            text=(
+                "Configure the executables, select the encrypted PDF, and tune the"
+                " password search strategy.  Use the buttons below to probe the"
+                " device, inspect the PDF metadata, or begin cracking."
+            ),
+            style="Intro.TLabel",
+        )
+        intro.grid(row=0, column=0, sticky=tk.W, pady=(0, 12))
 
-        add_labeled_entry(5, "Min Length:", self.min_length_var)
-        add_labeled_entry(6, "Max Length:", self.max_length_var)
-        add_labeled_entry(7, "Threads:", self.thread_var)
-        add_labeled_entry(8, "Custom Characters:", self.custom_chars_var)
+        executables_frame = ttk.LabelFrame(main_frame, text="Executables", style="Section.TLabelframe")
+        executables_frame.grid(row=1, column=0, sticky=tk.EW, pady=(0, 12))
+        executables_frame.columnconfigure(1, weight=1)
 
-        char_frame = tk.LabelFrame(main_frame, text="Character Classes", padx=10, pady=5)
-        char_frame.grid(row=9, column=0, columnspan=3, sticky=tk.EW, pady=5)
+        self._add_path_row(
+            executables_frame,
+            row=0,
+            label="PDF Retriever Binary",
+            variable=self.binary_var,
+            command=self._choose_binary,
+        )
+        self._add_path_row(
+            executables_frame,
+            row=1,
+            label="Device Probe",
+            variable=self.device_probe_var,
+            command=self._choose_device_probe,
+        )
+        self._add_entry_row(
+            executables_frame,
+            row=2,
+            label="Probe Options",
+            variable=self.device_probe_args_var,
+        )
+
+        pdf_frame = ttk.LabelFrame(main_frame, text="PDF & Wordlist", style="Section.TLabelframe")
+        pdf_frame.grid(row=2, column=0, sticky=tk.EW, pady=(0, 12))
+        pdf_frame.columnconfigure(1, weight=1)
+
+        self._add_path_row(pdf_frame, 0, "Encrypted PDF", self.pdf_var, self._choose_pdf)
+        self._add_path_row(pdf_frame, 1, "Wordlist", self.wordlist_var, self._choose_wordlist)
+
+        strategy_frame = ttk.LabelFrame(main_frame, text="Password Strategy", style="Section.TLabelframe")
+        strategy_frame.grid(row=3, column=0, sticky=tk.EW, pady=(0, 12))
+        for column in range(2):
+            strategy_frame.columnconfigure(column * 2 + 1, weight=1)
+
+        self._add_entry_row(strategy_frame, 0, "Min Length", self.min_length_var, column=0)
+        self._add_entry_row(strategy_frame, 0, "Max Length", self.max_length_var, column=1)
+        self._add_entry_row(strategy_frame, 1, "Threads", self.thread_var, column=0)
+        self._add_entry_row(strategy_frame, 1, "Custom Characters", self.custom_chars_var, column=1)
+
+        char_frame = ttk.LabelFrame(strategy_frame, text="Character Classes", style="Section.TLabelframe")
+        char_frame.grid(row=2, column=0, columnspan=4, sticky=tk.EW, pady=(12, 0))
+        for column in range(4):
+            char_frame.columnconfigure(column, weight=1)
 
         for column, (text, var) in enumerate((
             ("Uppercase", self.include_upper),
@@ -93,41 +163,103 @@ class UnlockPDFGui:
             ("Digits", self.include_digits),
             ("Special", self.include_special),
         )):
-            check = tk.Checkbutton(char_frame, text=text, variable=var,
-                                   command=self._refresh_character_state)
-            check.grid(row=0, column=column, sticky=tk.W)
+            check = ttk.Checkbutton(
+                char_frame,
+                text=text,
+                variable=var,
+                command=self._refresh_character_state,
+            )
+            check.grid(row=0, column=column, sticky=tk.W, padx=6)
             self._char_checkbuttons.append(check)
 
-        tk.Checkbutton(char_frame, text="Use Custom Only", variable=self.use_custom_only,
-                       command=self._refresh_character_state).grid(row=1, column=0, sticky=tk.W, pady=(5, 0))
+        ttk.Checkbutton(
+            char_frame,
+            text="Use Custom Characters Only",
+            variable=self.use_custom_only,
+            command=self._refresh_character_state,
+        ).grid(row=1, column=0, columnspan=4, sticky=tk.W, padx=6, pady=(8, 0))
 
-        button_frame = tk.Frame(main_frame, pady=10)
-        button_frame.grid(row=10, column=0, columnspan=3, sticky=tk.EW)
+        button_frame = ttk.Frame(main_frame)
+        button_frame.grid(row=4, column=0, sticky=tk.EW, pady=(0, 12))
+        button_frame.columnconfigure(4, weight=1)
 
-        self.probe_button = tk.Button(button_frame, text="Run Device Probe", command=self._run_device_probe)
-        self.probe_button.pack(side=tk.LEFT)
+        self.probe_button = ttk.Button(button_frame, text="Run Device Probe", command=self._run_device_probe)
+        self.probe_button.grid(row=0, column=0, padx=(0, 8))
 
-        self.info_button = tk.Button(button_frame, text="Get PDF Info", command=self._run_info)
-        self.info_button.pack(side=tk.LEFT, padx=10)
+        self.info_button = ttk.Button(button_frame, text="Get PDF Info", command=self._run_info)
+        self.info_button.grid(row=0, column=1, padx=(0, 8))
 
-        self.run_button = tk.Button(button_frame, text="Run Crack", command=self._run_cracker)
-        self.run_button.pack(side=tk.LEFT)
+        self.run_button = ttk.Button(button_frame, text="Run Crack", command=self._run_cracker)
+        self.run_button.grid(row=0, column=2, padx=(0, 8))
 
-        self.stop_button = tk.Button(button_frame, text="Stop", state=tk.DISABLED, command=self._stop_process)
-        self.stop_button.pack(side=tk.LEFT)
+        self.stop_button = ttk.Button(
+            button_frame,
+            text="Stop",
+            state=tk.DISABLED,
+            command=self._stop_process,
+        )
+        self.stop_button.grid(row=0, column=3, padx=(0, 8))
 
-        tk.Button(button_frame, text="Clear Output", command=self._clear_output).pack(side=tk.RIGHT)
+        ttk.Button(button_frame, text="Clear Output", command=self._clear_output).grid(
+            row=0,
+            column=4,
+            sticky=tk.E,
+        )
 
-        self.output = scrolledtext.ScrolledText(main_frame, height=20, wrap=tk.WORD)
-        self.output.grid(row=11, column=0, columnspan=3, sticky=tk.NSEW)
+        output_frame = ttk.LabelFrame(main_frame, text="Command Output", style="Section.TLabelframe")
+        output_frame.grid(row=5, column=0, sticky=tk.NSEW)
+        output_frame.columnconfigure(0, weight=1)
+        output_frame.rowconfigure(0, weight=1)
 
-        main_frame.rowconfigure(11, weight=1)
-        main_frame.columnconfigure(1, weight=1)
+        self.output = scrolledtext.ScrolledText(output_frame, height=16, wrap=tk.WORD)
+        self.output.grid(row=0, column=0, sticky=tk.NSEW)
 
-        status_frame = tk.Frame(self.master, padx=10, pady=5)
-        status_frame.pack(fill=tk.X)
-        tk.Label(status_frame, textvariable=self.status_var, anchor=tk.W).pack(fill=tk.X)
+        main_frame.rowconfigure(5, weight=1)
 
+        status_frame = ttk.Frame(self.master, padding=(15, 8, 15, 15))
+        status_frame.grid(row=1, column=0, sticky=tk.EW)
+        status_frame.columnconfigure(1, weight=1)
+
+        ttk.Label(status_frame, text="Status:", style="Status.TLabel").grid(row=0, column=0, sticky=tk.W)
+        ttk.Label(status_frame, textvariable=self.status_var).grid(row=0, column=1, sticky=tk.W, padx=(6, 0))
+
+        self.progress = ttk.Progressbar(status_frame, mode="indeterminate", maximum=80)
+        self.progress.grid(row=0, column=2, sticky=tk.E, ipadx=50)
+
+    def _add_entry_row(
+        self,
+        parent: ttk.Widget,
+        row: int,
+        label: str,
+        variable: tk.StringVar,
+        *,
+        column: int = 0,
+    ) -> ttk.Entry:
+        """Add a labelled entry to ``parent`` and return the widget."""
+
+        ttk.Label(parent, text=label).grid(row=row, column=column * 2, sticky=tk.W, padx=(0, 8), pady=4)
+        entry = ttk.Entry(parent, textvariable=variable, width=32)
+        entry.grid(row=row, column=column * 2 + 1, sticky=tk.EW, pady=4)
+        return entry
+
+    def _add_path_row(
+        self,
+        parent: ttk.Widget,
+        row: int,
+        label: str,
+        variable: tk.StringVar,
+        command,
+    ) -> None:
+        """Create a labelled entry with a browse button for file selection."""
+
+        ttk.Label(parent, text=label).grid(row=row, column=0, sticky=tk.W, padx=(0, 8), pady=4)
+        entry = ttk.Entry(parent, textvariable=variable, width=60)
+        entry.grid(row=row, column=1, sticky=tk.EW, pady=4)
+        ttk.Button(parent, text="Browse", command=command).grid(row=row, column=2, padx=(8, 0), pady=4)
+
+    # ------------------------------------------------------------------
+    # GUI helpers
+    # ------------------------------------------------------------------
     def _choose_binary(self) -> None:
         path = filedialog.askopenfilename(title="Select pdf_password_retriever executable")
         if path:
@@ -139,23 +271,31 @@ class UnlockPDFGui:
             self.device_probe_var.set(path)
 
     def _choose_pdf(self) -> None:
-        path = filedialog.askopenfilename(title="Select encrypted PDF", filetypes=[("PDF Files", "*.pdf"), ("All Files", "*.*")])
+        path = filedialog.askopenfilename(
+            title="Select encrypted PDF",
+            filetypes=[("PDF Files", "*.pdf"), ("All Files", "*.*")],
+        )
         if path:
             self.pdf_var.set(path)
 
     def _choose_wordlist(self) -> None:
-        path = filedialog.askopenfilename(title="Select wordlist", filetypes=[("Text Files", "*.txt"), ("All Files", "*.*")])
+        path = filedialog.askopenfilename(
+            title="Select wordlist",
+            filetypes=[("Text Files", "*.txt"), ("All Files", "*.*")],
+        )
         if path:
             self.wordlist_var.set(path)
 
     def _refresh_character_state(self) -> None:
         is_custom_only = self.use_custom_only.get()
-        for var in (self.include_upper, self.include_lower, self.include_digits, self.include_special):
-            if is_custom_only:
+        if is_custom_only:
+            for var in (self.include_upper, self.include_lower, self.include_digits, self.include_special):
                 var.set(False)
-        state = tk.DISABLED if is_custom_only else tk.NORMAL
         for widget in self._char_checkbuttons:
-            widget.configure(state=state)
+            if is_custom_only:
+                widget.state(["disabled"])
+            else:
+                widget.state(["!disabled"])
 
     def _clear_output(self) -> None:
         self.output.delete("1.0", tk.END)
@@ -164,8 +304,12 @@ class UnlockPDFGui:
         def append() -> None:
             self.output.insert(tk.END, text)
             self.output.see(tk.END)
+
         self.master.after(0, append)
 
+    # ------------------------------------------------------------------
+    # Command handling
+    # ------------------------------------------------------------------
     def _validate_binary(self) -> str | None:
         binary = self.binary_var.get().strip() or default_binary_path()
         binary_path = Path(binary)
@@ -254,7 +398,6 @@ class UnlockPDFGui:
                 args.append("--include-special")
             else:
                 args.append("--exclude-special")
-
         return args
 
     def _run_info(self) -> None:
@@ -277,7 +420,8 @@ class UnlockPDFGui:
         device_probe = self._validate_device_probe()
         if not device_probe:
             return
-        extra_args = shlex.split(self.device_probe_args_var.get()) if self.device_probe_args_var.get().strip() else []
+        raw_args = self.device_probe_args_var.get().strip()
+        extra_args = shlex.split(raw_args) if raw_args else []
         command = [device_probe] + extra_args
         header = "Running device_probe benchmark\n"
         if extra_args:
@@ -342,19 +486,33 @@ class UnlockPDFGui:
     def _toggle_buttons(self, running: bool) -> None:
         state_run = tk.DISABLED if running else tk.NORMAL
         state_stop = tk.NORMAL if running else tk.DISABLED
+
         def update() -> None:
-            self.run_button.configure(state=state_run)
-            self.info_button.configure(state=state_run)
-            self.probe_button.configure(state=state_run)
+            for widget in (self.run_button, self.info_button, self.probe_button):
+                widget.configure(state=state_run)
             self.stop_button.configure(state=state_stop)
-            if not running and self.status_var.get() in {"Running...", "Stopping..."}:
-                self.status_var.set("Idle")
+            if running:
+                self.progress.start(12)
+            else:
+                self.progress.stop()
+                if self.status_var.get() in {"Running...", "Stopping..."}:
+                    self.status_var.set("Idle")
+
         self.master.after(0, update)
 
     def _set_status(self, message: str) -> None:
         def update() -> None:
             self.status_var.set(message)
+
         self.master.after(0, update)
+
+    def _on_close(self) -> None:
+        """Ensure background threads are notified before closing the window."""
+
+        self._stop_process()
+        if self._runner and self._runner.is_alive():
+            self._runner.join(timeout=0.5)
+        self.master.destroy()
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- restyle the Tkinter interface around themed ttk widgets and reorganised sections for executables, PDF inputs, and password strategy
- add contextual guidance, progress feedback, and graceful shutdown handling to polish the user experience
- retain existing command construction while clarifying helper routines and button wiring

## Testing
- python -m compileall gui/unlock_pdf_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68dffdde01388332a3af4e7c2a98323c